### PR TITLE
Rollback SBT carpe version to 0.8.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 // CarpeData's shared project configuration plugin to jumpstart your projects
 resolvers += "Artifactory Realm" at "https://bin.carpe.io/artifactory/sbt-release"
 credentials += Credentials(new File(Properties.envOrElse("JENKINS_HOME", Properties.envOrElse("HOME", "")) + "/.sbt/.credentials"))
-addSbtPlugin("io.carpe" % "sbt-carpe" % "1.1.0")
+addSbtPlugin("io.carpe" % "sbt-carpe" % "0.8.1")
 


### PR DESCRIPTION
*sbt carpe plugin back to 0.8.1 to have s3 as backup resolver and publisher for carpe libs
