### PR TITLE
add additional support for managing custom domain name mappings

### DIFF
--- a/plugin/src/main/scala/io/carpe/scalambda/conf/ScalambdaFunction.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/ScalambdaFunction.scala
@@ -1,5 +1,6 @@
 package io.carpe.scalambda.conf
 
+import io.carpe.scalambda.conf.api.ApiGatewayConfig
 import io.carpe.scalambda.conf.function.FunctionNaming.Static
 import io.carpe.scalambda.conf.function._
 import io.carpe.scalambda.conf.utils.StringUtils

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/api/ApiDomain.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/api/ApiDomain.scala
@@ -1,0 +1,39 @@
+package io.carpe.scalambda.conf.api
+
+import io.carpe.scalambda.terraform.ast.props.TValue
+import io.carpe.scalambda.terraform.ast.props.TValue.{TString, TVariableRef}
+
+sealed trait ApiDomain {
+  def map[R](f: TValue => R): Option[R]
+}
+
+object ApiDomain {
+
+  /**
+   * Refuse to map the domain name to any thing
+   */
+  case object Unmapped extends ApiDomain {
+    override def map[R](f: TValue => R): Option[R] = None
+  }
+
+  /**
+   * The Api's domain name will be retrieved from a generated terraform variable.
+   */
+  case object FromVariable extends ApiDomain {
+    lazy val apiDomainVariableName: String = "domain_name"
+    lazy val asTValue: TValue = TVariableRef(apiDomainVariableName)
+
+    override def map[R](f: TValue => R): Option[R] = Some(f.apply(this.asTValue))
+  }
+
+  /**
+   * Sets the deployment/stage of the Api as the root Custom Domain Mapping for the given url.
+   *
+   * @param domain to connect api to as the root mapping
+   */
+  case class Static(domain: String) extends ApiDomain {
+    lazy val asTValue: TValue = TString(domain)
+
+    override def map[R](f: TValue => R): Option[R] = Some(f.apply(this.asTValue))
+  }
+}

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/api/ApiGatewayConfig.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/api/ApiGatewayConfig.scala
@@ -1,0 +1,5 @@
+package io.carpe.scalambda.conf.api
+
+import io.carpe.scalambda.conf.function.{Auth, Method}
+
+case class ApiGatewayConfig(route: String, method: Method, authConf: Auth)

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/function/ApiGatewayConfig.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/function/ApiGatewayConfig.scala
@@ -1,3 +1,0 @@
-package io.carpe.scalambda.conf.function
-
-case class ApiGatewayConfig(route: String, method: Method, authConf: AuthConfig)

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/function/Auth.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/function/Auth.scala
@@ -4,11 +4,11 @@ import io.carpe.scalambda.terraform.openapi.SecurityDefinition
 import io.carpe.scalambda.terraform.openapi.SecurityDefinition.Authorizer
 import io.carpe.scalambda.terraform.openapi.resourcemethod.Security
 
-sealed trait AuthConfig {
+sealed trait Auth {
   def authorizer: Option[SecurityDefinition]
 }
 
-object AuthConfig {
+object Auth {
 
   /**
    * A Custom Authorizer that you can use to implement your own auth logic for ApiGateway
@@ -16,7 +16,7 @@ object AuthConfig {
    * @param authorizerArn invoke arn for your authorizer (example: s"arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:1234567889:function:MyAuthorizer/invocations")
    * @param authorizerRole role to assume to allow invocation of your authorizer
    */
-  case class Authorizer(authorizerName: String, authorizerArn: String, authorizerRole: String) extends AuthConfig {
+  case class Authorizer(authorizerName: String, authorizerArn: String, authorizerRole: String) extends Auth {
     override def authorizer: Option[SecurityDefinition] = Some(SecurityDefinition.Authorizer(
       authorizerName = authorizerName,
       authorizerArn = authorizerArn,
@@ -24,11 +24,11 @@ object AuthConfig {
     ))
   }
 
-  case object ApiKey extends AuthConfig {
+  case object ApiKey extends Auth {
     override def authorizer: Option[SecurityDefinition] = Some(SecurityDefinition.ApiKey)
   }
 
-  case object AllowAll extends AuthConfig {
+  case object AllowAll extends Auth {
     override def authorizer: Option[SecurityDefinition] = None
   }
 

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/keys/ApiGatewayKeys.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/keys/ApiGatewayKeys.scala
@@ -1,7 +1,9 @@
 package io.carpe.scalambda.conf.keys
 
+import io.carpe.scalambda.conf.api
+import io.carpe.scalambda.conf.api.{ApiDomain, ApiGatewayConfig}
 import sbt.settingKey
-import io.carpe.scalambda.conf.function.{ApiGatewayConfig, AuthConfig, Method}
+import io.carpe.scalambda.conf.function.{Auth, Method}
 
 trait ApiGatewayKeys {
 
@@ -9,27 +11,43 @@ trait ApiGatewayKeys {
    * Api related settings
    */
 
+  lazy val domainName = settingKey[ApiDomain]("Domain name to be used in the terraform output")
+
   lazy val apiName = settingKey[String]("Prefix for the name of the api. Defaults to project name")
+
   lazy val apiAuthorizerArn = settingKey[String]("Arn for custom authorizer to use for ApiGateway")
 
   /**
-   * Helpers for configuration
+   * Helpers for domain settings
    */
 
-  def post(route: String, authConf: AuthConfig = AuthConfig.AllowAll): ApiGatewayConfig = {
-    ApiGatewayConfig(route = route, method = Method.POST, authConf)
+  lazy val ApiDomain: io.carpe.scalambda.conf.api.ApiDomain.type = io.carpe.scalambda.conf.api.ApiDomain
+
+  /**
+   * Helpers for auth
+   */
+
+  lazy val Auth: io.carpe.scalambda.conf.function.Auth.type = io.carpe.scalambda.conf.function.Auth
+
+
+  /**
+   * Helpers for endpoint configuration
+   */
+
+  def post(route: String, authConf: Auth = Auth.AllowAll): ApiGatewayConfig = {
+    api.ApiGatewayConfig(route = route, method = Method.POST, authConf)
   }
 
-  def get(route: String, authConf: AuthConfig = AuthConfig.AllowAll): ApiGatewayConfig = {
-    ApiGatewayConfig(route = route, method = Method.GET, authConf)
+  def get(route: String, authConf: Auth = Auth.AllowAll): ApiGatewayConfig = {
+    api.ApiGatewayConfig(route = route, method = Method.GET, authConf)
   }
 
-  def put(route: String, authConf: AuthConfig = AuthConfig.AllowAll): ApiGatewayConfig = {
-    ApiGatewayConfig(route = route, method = Method.PUT, authConf)
+  def put(route: String, authConf: Auth = Auth.AllowAll): ApiGatewayConfig = {
+    api.ApiGatewayConfig(route = route, method = Method.PUT, authConf)
   }
 
-  def delete(route: String, authConf: AuthConfig = AuthConfig.AllowAll): ApiGatewayConfig = {
-    ApiGatewayConfig(route = route, method = Method.DELETE, authConf)
+  def delete(route: String, authConf: Auth = Auth.AllowAll): ApiGatewayConfig = {
+    api.ApiGatewayConfig(route = route, method = Method.DELETE, authConf)
   }
 
 }

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/keys/AssemblyKeys.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/keys/AssemblyKeys.scala
@@ -1,0 +1,20 @@
+package io.carpe.scalambda.conf.keys
+
+import sbt._
+import sbtassembly.MergeStrategy
+
+/**
+ * Tasks and Settings related to the creation of jar and zip files to be used by AWS Lambda.
+ */
+trait AssemblyKeys {
+
+    lazy val scalambdaPackageMergeStrat =
+      settingKey[String => MergeStrategy]("mapping from archive member path to merge strategy")
+    lazy val scalambdaPackage = taskKey[File]("Create jar (without dependencies) for your Lambda Function(s)")
+
+    lazy val scalambdaDependenciesMergeStrat =
+      settingKey[String => MergeStrategy]("mapping from archive member path to merge strategy")
+    lazy val scalambdaPackageDependencies = taskKey[File](
+      "Create a jar containing all the dependencies for your Lambda Function(s). This will be used as a Lambda Layer to support your function."
+    )
+}

--- a/plugin/src/main/scala/io/carpe/scalambda/conf/keys/ScalambaKeys.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/conf/keys/ScalambaKeys.scala
@@ -8,3 +8,4 @@ trait ScalambaKeys
     with RuntimeKeys
     with WarmerKeys
     with BillingTagKeys
+    with AssemblyKeys

--- a/plugin/src/main/scala/io/carpe/scalambda/terraform/OpenApi.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/terraform/OpenApi.scala
@@ -1,7 +1,7 @@
 package io.carpe.scalambda.terraform
 
 import io.carpe.scalambda.conf.ScalambdaFunction
-import io.carpe.scalambda.conf.function.ApiGatewayConfig
+import io.carpe.scalambda.conf.api.ApiGatewayConfig
 import io.carpe.scalambda.terraform.openapi.{ResourceMethod, ResourcePath, SecurityDefinition}
 
 case class OpenApi(paths: Seq[ResourcePath], securityDefinitions: Seq[SecurityDefinition])

--- a/plugin/src/main/scala/io/carpe/scalambda/terraform/ast/providers/aws/apigateway/ApiGatewayDomainName.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/terraform/ast/providers/aws/apigateway/ApiGatewayDomainName.scala
@@ -4,7 +4,7 @@ import io.carpe.scalambda.terraform.ast.Definition.{Resource, Variable}
 import io.carpe.scalambda.terraform.ast.props.TValue
 import io.carpe.scalambda.terraform.ast.props.TValue.{TBool, TLiteral, TString, TVariableRef}
 
-case class ApiGatewayDomainName(name: String, domainName: String, certificateArn: TValue, toggle: Variable[TBool]) extends Resource {
+case class ApiGatewayDomainName(name: String, domainName: TValue, certificateArn: TValue, toggle: Variable[TBool]) extends Resource {
   /**
    * Examples: "aws_lambda_function" "aws_iam_role"
    */
@@ -15,7 +15,7 @@ case class ApiGatewayDomainName(name: String, domainName: String, certificateArn
    */
   override def body: Map[String, TValue] = Map(
     "count" -> TLiteral(s"var.${toggle.name} ? 1 : 0"),
-    "domain_name" -> TString(domainName),
+    "domain_name" -> domainName,
     "certificate_arn" -> certificateArn
   )
 }

--- a/plugin/src/main/scala/io/carpe/scalambda/terraform/openapi/ResourcePath.scala
+++ b/plugin/src/main/scala/io/carpe/scalambda/terraform/openapi/ResourcePath.scala
@@ -1,7 +1,8 @@
 package io.carpe.scalambda.terraform.openapi
 
 import io.carpe.scalambda.conf.ScalambdaFunction
-import io.carpe.scalambda.conf.function.{ApiGatewayConfig, Method}
+import io.carpe.scalambda.conf.api.ApiGatewayConfig
+import io.carpe.scalambda.conf.function.Method
 
 case class ResourcePath(name: String, post: Option[ResourceMethod], get: Option[ResourceMethod], put: Option[ResourceMethod], delete: Option[ResourceMethod], options: Option[ResourceMethod]) {
   def addFunction(apiConfig: ApiGatewayConfig, function: ScalambdaFunction): ResourcePath = {

--- a/plugin/src/test/scala/io/carpe/scalambda/fixtures/ScalambdaFunctionFixtures.scala
+++ b/plugin/src/test/scala/io/carpe/scalambda/fixtures/ScalambdaFunctionFixtures.scala
@@ -2,6 +2,7 @@ package io.carpe.scalambda.fixtures
 
 import io.carpe.scalambda.conf.ScalambdaFunction
 import io.carpe.scalambda.conf.ScalambdaFunction.{ApiFunction, ProjectFunction}
+import io.carpe.scalambda.conf.api.ApiGatewayConfig
 import io.carpe.scalambda.conf.function.FunctionNaming.Static
 import io.carpe.scalambda.conf.function.FunctionSource.IncludedInModule
 import io.carpe.scalambda.conf.function._
@@ -17,7 +18,7 @@ trait ScalambdaFunctionFixtures { this: AnyFlatSpec =>
       functionSource = IncludedInModule,
       iamRole = FunctionRoleSource.StaticArn("arn:aws:iam::12345678900:role/lambda_basic_execution"),
       runtimeConfig = RuntimeConfig.default,
-      apiConfig = ApiGatewayConfig(route = "/cars", method = Method.GET, authConf = AuthConfig.Authorizer("my_authorizer", "arn:fake:my_authorizer/invocations", "arn:fake:MyRole")),
+      apiConfig = ApiGatewayConfig(route = "/cars", method = Method.GET, authConf = Auth.Authorizer("my_authorizer", "arn:fake:my_authorizer/invocations", "arn:fake:MyRole")),
       vpcConfig = VpcConf.withoutVpc,
       warmerConfig = WarmerConfig.Cold,
       environmentVariables = List.empty


### PR DESCRIPTION
Domain Name mappings can be configured via setting the `apiDomain` setting key with value from the `ApiDomain` object/sealed trait

Added the following attributes to the terraform module output (if the module contains an Api Gateway definition and the user would rather handle Api Domain Name mappings themselves):
`rest_api_id`
`rest_api_deployment_id`
`rest_api_stage_name`